### PR TITLE
Aplica un algoritmo más robusto + refactoriza en funciones

### DIFF
--- a/src/list.php
+++ b/src/list.php
@@ -123,7 +123,7 @@ foreach ($results as &$result) {
 	// "Romana, la" en vez de "La Romana"
 	$municipio = $result['Municipio'];
 	if (preg_match("/(.{2,})((\,\s{0,1})([A-Za-z]{1,3}))$/", $result['Municipio'])) { // Comprueba si hay una serie de caracteres, una coma y luego otra sucesión de entre 1 y 3 caracteres
-		$municipio = trim(preg_replace("/(.{2,})((\,\s{0,1})([A-Za-z]{1,3}))$/", '${4} ${1}', $result['Municipio']));
+		$municipio = trim(preg_replace("/(.{2,})((\,\s{0,1})([A-Za-z]{1,5}))$/", '${4} ${1}', $result['Municipio']));
 	}
 
 	// ... y ajustar la capitalización y los espacios al principio y al final

--- a/src/list.php
+++ b/src/list.php
@@ -122,9 +122,12 @@ foreach ($results as &$result) {
 	// Modificar los municipios que llevan el artículo al final
 	// "Romana, la" en vez de "La Romana"
 	$municipio = $result['Municipio'];
-	if (preg_match("/(.{2,})((\,\s{0,1})([A-Za-z]{1,5}))$/", $result['Municipio'])) {
-		$municipio = preg_replace("/(.{2,})((\,\s{0,1})([A-Za-z]{1,5}))$/", '${4} ${1}', $result['Municipio']);
+	if (preg_match("/(.{2,})((\,\s{0,1})([A-Za-z]{1,3}))$/", $result['Municipio'])) { // Comprueba si hay una serie de caracteres, una coma y luego otra sucesión de entre 1 y 3 caracteres
+		$municipio = trim(preg_replace("/(.{2,})((\,\s{0,1})([A-Za-z]{1,3}))$/", '${4} ${1}', $result['Municipio']));
 	}
+
+	// ... y ajustar la capitalización y los espacios al principio y al final
+	$municipio = mb_convert_case(trim($municipio), MB_CASE_TITLE);
 
 	$candidato = [
 		'Número de orden' => $result['Número de orden del candidato'],

--- a/src/list.php
+++ b/src/list.php
@@ -48,7 +48,7 @@ $file = parseName($argv[1]);
  * Para la decodificación de los municipios la especificación oficial remite al INE.
  * Pero los códigos cambian a comienzos de cada año, por lo que se hace preciso cargar
  * la del año correspondiente.
- * 
+ *
  * Y además es precesio añadir a la correspondencia los códigos que el Ministerio ha utilizado
  * históricamente pero que el INE actualmente no reconoce.
  */
@@ -119,13 +119,20 @@ foreach ($results as &$result) {
 
 	$candidatura = $result['Candidatura'];
 
+	// Modificar los municipios que llevan el artículo al final
+	// "Romana, la" en vez de "La Romana"
+	$municipio = $result['Municipio'];
+	if (preg_match("/(.{2,})((\,\s{0,1})([A-Za-z]{1,5}))$/", $result['Municipio'])) {
+		$municipio = preg_replace("/(.{2,})((\,\s{0,1})([A-Za-z]{1,5}))$/", '${4} ${1}', $result['Municipio']);
+	}
+
 	$candidato = [
 		'Número de orden' => $result['Número de orden del candidato'],
 		'Elegido' => $result['Elegido'],
 		'Sexo' => $result['Sexo'] ?? null,
 		'Candidato' => $nombre,
 		'Provincia' => $result['Provincia'],
-		'Municipio' => $result['Municipio'],
+		'Municipio' => $municipio,
 		'Siglas' => $candidaturas[$candidatura]['Siglas'] ?? null,
 		'Candidatura' => $candidaturas[$candidatura]['Candidatura'] ?? null,
 	];

--- a/src/list.php
+++ b/src/list.php
@@ -100,34 +100,11 @@ foreach ($results as &$result) {
 		}
 	}
 
-	// Hagamos un mínimo embellecimiento de la capitalización...
-	$nombre = mb_convert_case($nombre, MB_CASE_TITLE);
-	$map = [
-		'/ De La /' => ' de la ',
-		'/ Del /' => ' del ',
-		'/ De /' => ' de ',
-		'/ Y /' => ' y ',
-		'/ I /' => ' i ',
-		'/ E /' => ' e ',
-	];
-	$nombre = preg_replace(array_keys($map), array_values($map), $nombre);
+	$nombre = prettifyName($nombre);
 
-	// ...y erradiquemos también los sufijos que entre paréntesis constan a veces. Ejemplos:
-	// - `Ramon Marrero Garcia (Independiente)`
-	// - `Celestino Gonzalez Bolaños (PCE L-M)`
-	$nombre = trim(preg_replace('/\(.+\)\s*$/', '', $nombre));
+	$municipio = prettifyMunicipality($result['Municipio']);
 
 	$candidatura = $result['Candidatura'];
-
-	// Modificar los municipios que llevan el artículo al final
-	// "Romana, la" en vez de "La Romana"
-	$municipio = $result['Municipio'];
-	if (preg_match("/(.{2,})((\,\s{0,1})([A-Za-z]{1,3}))$/", $result['Municipio'])) { // Comprueba si hay una serie de caracteres, una coma y luego otra sucesión de entre 1 y 3 caracteres
-		$municipio = trim(preg_replace("/(.{2,})((\,\s{0,1})([A-Za-z]{1,5}))$/", '${4} ${1}', $result['Municipio']));
-	}
-
-	// ... y ajustar la capitalización y los espacios al principio y al final
-	$municipio = mb_convert_case(trim($municipio), MB_CASE_TITLE);
 
 	$candidato = [
 		'Número de orden' => $result['Número de orden del candidato'],


### PR DESCRIPTION
1. Aplica un algoritmo de embellecimiento de municipios válido también para el caso de municipios con dos nombres. Por ejemplo, `Alqueries, les/Alquerías del Niño Perdido`. También mejora el criterio para identificar artículos (`El`, 'Las', 'O', 'Els'...), pues se buscan expresamente los artículos empleados en los municipios españoles en lugar de detectarse heurísticamente por su longitud. Este algoritmo resuelve satisfactoriamente todos los escenarios descritos en #1.

2. Mueve a sendas funciones este algoritmo y el que embellece los nombres de los candidatos.